### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ Pimp My Pillow
     :alt: PyPI Package monthly downloads
     :target: https://pypi.python.org/pypi/pimpmypillow/
 
-.. |wheel| image:: https://pypip.in/wheel/pmp/badge.png?style=flat
+.. |wheel| image:: https://img.shields.io/pypi/wheel/pmp.svg?style=flat
     :alt: PyPI Wheel
     :target: https://pypi.python.org/pypi/pimpmypillow/
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20pimpmypillow))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `pimpmypillow`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.